### PR TITLE
Closes #5 Improved project organisation by eliminating docbook in project root.

### DIFF
--- a/build.fish
+++ b/build.fish
@@ -12,16 +12,20 @@ function transform_dicom_part -a output_xml input_xml xsl
 end
 
 function download_deps -a part
-  if not test -d docbook
-    mkdir docbook
+  if not test -d build
+    mkdir build
   end
 
-  if not test -d docbook/$part
-    mkdir docbook/$part
+  if not test -d build/docbook
+    mkdir build/docbook
   end
 
-  if not test -e docbook/$part/$part.xml
-    wget -O docbook/$part/$part.xml -c http://dicom.nema.org/medical/dicom/current/source/docbook/$part/$part.xml
+  if not test -d build/docbook/$part
+    mkdir build/docbook/$part
+  end
+
+  if not test -e build/docbook/$part/$part.xml
+    wget -O build/docbook/$part/$part.xml -c http://dicom.nema.org/medical/dicom/current/source/docbook/$part/$part.xml
   end
 end
 
@@ -33,7 +37,7 @@ rm -f build/*.xml
 
 download_deps part03
 download_deps part06
-transform_dicom_part build/registry.xml docbook/part06/part06.xml src/data_dictionary.xsl
-transform_dicom_part build/macros.xml docbook/part03/part03.xml src/macro_attributes.xsl
-transform_dicom_part build/modules.xml docbook/part03/part03.xml src/module_attributes.xsl
-transform_dicom_part build/ciod_modules.xml docbook/part03/part03.xml src/ciod_modules.xsl
+transform_dicom_part build/registry.xml build/docbook/part06/part06.xml src/data_dictionary.xsl
+transform_dicom_part build/macros.xml build/docbook/part03/part03.xml src/macro_attributes.xsl
+transform_dicom_part build/modules.xml build/docbook/part03/part03.xml src/module_attributes.xsl
+transform_dicom_part build/ciod_modules.xml build/docbook/part03/part03.xml src/ciod_modules.xsl

--- a/build.sh
+++ b/build.sh
@@ -18,14 +18,17 @@ transform_dicom_part() {
 
 download_deps() {
   # arg1: DICOM part
-  if [ ! -d docbook ]; then
-    mkdir docbook
+  if [ ! -d build ]; then
+    mkdir build
   fi
-  if [ ! -d "docbook/$1" ]; then
-    mkdir "docbook/$1"
+  if [ ! -d build/docbook ]; then
+    mkdir build/docbook
   fi
-  if [ ! -e "docbook/$1/$1.xml" ]; then
-    wget -O "docbook/$1/$1.xml" -c http://dicom.nema.org/medical/dicom/current/source/docbook/$1/$1.xml
+  if [ ! -d "build/docbook/$1" ]; then
+    mkdir "build/docbook/$1"
+  fi
+  if [ ! -e "build/docbook/$1/$1.xml" ]; then
+    wget -O "build/docbook/$1/$1.xml" -c http://dicom.nema.org/medical/dicom/current/source/docbook/$1/$1.xml
   fi
 }
 
@@ -37,7 +40,7 @@ rm -f build/*.xml
 
 download_deps part03
 download_deps part06
-transform_dicom_part build/registry.xml docbook/part06/part06.xml src/data_dictionary.xsl
-transform_dicom_part build/macros.xml docbook/part03/part03.xml src/macro_attributes.xsl
-transform_dicom_part build/modules.xml docbook/part03/part03.xml src/module_attributes.xsl
-transform_dicom_part build/ciod_modules.xml docbook/part03/part03.xml src/ciod_modules.xsl
+transform_dicom_part build/registry.xml build/docbook/part06/part06.xml src/data_dictionary.xsl
+transform_dicom_part build/macros.xml build/docbook/part03/part03.xml src/macro_attributes.xsl
+transform_dicom_part build/modules.xml build/docbook/part03/part03.xml src/module_attributes.xsl
+transform_dicom_part build/ciod_modules.xml build/docbook/part03/part03.xml src/ciod_modules.xsl


### PR DESCRIPTION
Eliminate docbook directory in the project directory. 

Updated both 'build.fish' and 'build.sh' scripts to create docbook directory within the existing build directory. Previously, docbook directories were being created in the project root. This created unnecessary clutter. This change improves project organization.